### PR TITLE
Fix typo in `<d1>` tag (rather than `<dl>`)

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -359,7 +359,7 @@ At any point during the creation of the {{Socket}} instance, `connect` may throw
 
 <h3 id="socketinfo-dictionary">`SocketInfo` dictionary</h3>
 
-<d1>
+<dl>
   <dt>
     {{remoteAddress}} member
   </dt>
@@ -379,7 +379,7 @@ At any point during the creation of the {{Socket}} instance, `connect` may throw
   <dd>
     If the server agrees with one of the protocols specified in the `alpn` negotiation list, returns that protocol name as a string, otherwise `null`. 
   </dd>
-</d1>
+</dl>
 
 <h3 id="anysocketaddress-type">`AnySocketAddress` type</h3>
 


### PR DESCRIPTION
In the HTML rendered version of the spec, this typo results in the last section of the spec (the `AnySocketAddress` type) being indented.

This is due to Bikeshed removing the `</dd>` close tag because in HTML it almost always is optional, but in this case it resulted in the remainder of the spec content being pulled inside the `<dd>` element. The only parts that are not pulled are those after the Bikeshed-inserted `</main>` close tag, which correspond to the boilerplate sections inserted at the end of the document.